### PR TITLE
update rackspace/php-opencloud to 1.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "rackspace/php-opencloud": "~1.7.0"
+        "rackspace/php-opencloud": "1.*"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*"


### PR DESCRIPTION
Those who use guzzle > 3.7.x in their own projects need to use rackspace/php-opencloud > 1.7.x to avoid composer-conflicts.
